### PR TITLE
feat: Add LCG Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ As it isn't reasonable for the `pyhf` dev team to expect that everyone who uses 
 
 * https://gitlab.cern.ch/rles/pyfittools
 * https://gitlab.cern.ch/ekourlit/pyfits
+* https://lcginfo.cern.ch/pkg/pyhf/ (LCG Views)


### PR DESCRIPTION
* https://lcginfo.cern.ch/pkg/pyhf/
   - The pyhf dev team is responsible for opening issues to update pyhf versions in LCG releases.